### PR TITLE
NavSingleItem: Allow setting a target attribute to an external item

### DIFF
--- a/src/_nav.js
+++ b/src/_nav.js
@@ -125,6 +125,7 @@ export default {
       url: 'https://github.com/NiceDash/Vibe',
       icon: 'GitHub',
       external: true,
+      target: '_blank',
     },
     {
       name: 'Account',

--- a/src/vibe/components/SidebarNav/components/NavSingleItem.js
+++ b/src/vibe/components/SidebarNav/components/NavSingleItem.js
@@ -8,7 +8,7 @@ const NavSingleItem = ({ item }) => {
   if (item.external) {
     return (
       <li className="nav-item">
-        <a href={item.url}>
+        <a href={item.url} target={item.target}>
           {item.icon && Icon && <Icon className="side-nav-icon" />}
           <span className="nav-item-label">{item.name}</span>
           {item.badge && <NavBadge color={item.badge.variant} text={item.badge.text} />}

--- a/src/vibe/components/SidebarNav/components/NavSingleItem.js
+++ b/src/vibe/components/SidebarNav/components/NavSingleItem.js
@@ -6,11 +6,7 @@ import NavBadge from './NavBadge';
 const NavSingleItem = ({ item }) => {
   const Icon = item.icon && Feather[item.icon] ? Feather[item.icon] : null;
   if (item.external) {
-    let rel = null;
-    
-    if("target" in item && item.target === "_blank") {
-      rel = "noopener noreferrer";
-    }
+    const rel = item.target && item.target === '_blank' ? 'noopener noreferrer' : null;
     
     return (
       <li className="nav-item">

--- a/src/vibe/components/SidebarNav/components/NavSingleItem.js
+++ b/src/vibe/components/SidebarNav/components/NavSingleItem.js
@@ -6,9 +6,15 @@ import NavBadge from './NavBadge';
 const NavSingleItem = ({ item }) => {
   const Icon = item.icon && Feather[item.icon] ? Feather[item.icon] : null;
   if (item.external) {
+    let rel = null;
+    
+    if("target" in item && item.target === "_blank") {
+      rel = "noopener noreferrer";
+    }
+    
     return (
       <li className="nav-item">
-        <a href={item.url} target={item.target}>
+        <a href={item.url} target={item.target} rel={rel}>
           {item.icon && Icon && <Icon className="side-nav-icon" />}
           <span className="nav-item-label">{item.name}</span>
           {item.badge && <NavBadge color={item.badge.variant} text={item.badge.text} />}


### PR DESCRIPTION
Sample from `_nav.js`:

```javascript
bottom: [
    {
      name: 'Get Vibe',
      url: 'https://github.com/NiceDash/Vibe',
      icon: 'GitHub',
      external: true,
      target: '_blank'
    }
```

I would keep it as an option and not link to external items with a `_blank` target as default.