### PR TITLE
Only focus Sidebar on keyboard navigation

### DIFF
--- a/src/layouts/DashboardLayout.js
+++ b/src/layouts/DashboardLayout.js
@@ -7,6 +7,7 @@ import avatar1 from '../assets/images/avatar1.png';
 import nav from '../_nav';
 import routes from '../views';
 import ContextProviders from '../vibe/components/utilities/ContextProviders';
+import handleKeyAccessibility, { handleClickAccessibility } from '../vibe/helpers/handleTabAccessibility';
 
 const MOBILE_SIZE = 992;
 
@@ -36,6 +37,8 @@ export default class DashboardLayout extends Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
+    document.addEventListener('keydown', handleKeyAccessibility);
+    document.addEventListener('click', handleClickAccessibility);
   }
 
   componentWillUnmount() {

--- a/src/vibe/components/SidebarNav/components/NavDropdownItem.js
+++ b/src/vibe/components/SidebarNav/components/NavDropdownItem.js
@@ -11,9 +11,9 @@ export default class NavDropdownItem extends Component {
     };
   }
   toggle = e => {
+    this.setState(prevState => ({ open: !prevState.open }));
     e.preventDefault();
     e.stopPropagation();
-    this.setState(prevState => ({ open: !prevState.open }));
   };
   render() {
     const { item } = this.props;

--- a/src/vibe/helpers/handleTabAccessibility.js
+++ b/src/vibe/helpers/handleTabAccessibility.js
@@ -1,0 +1,15 @@
+const handleKeyAccessibility = e => {
+  const TABKEYCODE = 9;
+  const ENTERKEYCODE = 13;
+  if (e.keyCode === TABKEYCODE || ENTERKEYCODE) {
+    document.querySelector('body').classList.add('keyboardActive');
+  }
+};
+
+export const handleClickAccessibility = e => {
+  if (e.detail !== 0) { // Determines if event is mouse click or keyboard "click"
+    document.querySelector('body').classList.remove('keyboardActive');
+  }
+};
+
+export default handleKeyAccessibility;

--- a/src/vibe/scss/components/primaryNav.scss
+++ b/src/vibe/scss/components/primaryNav.scss
@@ -35,7 +35,7 @@
     font-weight: bold;
     margin-right: 0;
 
-    &:focus {
+    .keyboardActive &:focus {
       outline: none;
       box-shadow: inset 0px 0px 0px 2px $activeNavBorderColor !important;
     }
@@ -102,7 +102,7 @@
         .nav-item {
           background: darken($sidenavBgHover, 4%);
 
-          &:focus,
+          .keyboardActive &:focus,
           &:hover {
             a {
               background: darken($sidenavBgHover, 6%);
@@ -116,7 +116,7 @@
               background: darken($sidenavBgHover, 6%);
             }
 
-            &:focus {
+            .keyboardActive &:focus {
               outline: none;
               box-shadow: inset 0px 0px 0px 2px $activeNavBorderColor;
             }
@@ -153,6 +153,9 @@
 
       &:focus {
         outline: none;
+      }
+
+      .keyboardActive &:focus {
         box-shadow: inset 0px 0px 0px 2px $activeNavBorderColor !important;
       }
 
@@ -282,7 +285,7 @@
             }
           }
 
-          &:focus,
+          .keyboardActive &:focus,
           &:hover {
             .nav-submenu {
               position: absolute;


### PR DESCRIPTION
This PR fixes focus states on mouse click for the sidebar navigation. There is no point to show it when using the mouse. It still works for keyboard navigation. This code could potentially be used for other elements as well.

Before:
![before](https://user-images.githubusercontent.com/3262856/66883690-5f9f8980-ef94-11e9-86eb-3127e4a7074b.gif)

After: 
![after](https://user-images.githubusercontent.com/3262856/66883695-675f2e00-ef94-11e9-8b7a-1db048b7d37b.gif)
